### PR TITLE
Updated vendor script for Python 3.12 depreciation of SafeConfigParser

### DIFF
--- a/cython_setuptools/vendor.py
+++ b/cython_setuptools/vendor.py
@@ -13,6 +13,18 @@ if PY3:
 else:
     import ConfigParser as configparser
 
+PY312 = sys.version_info[1] >= 12
+if PY312:
+    def read_config(fp):
+        config = configparser.ConfigParser()
+        config.read_file(fp)
+        return config
+else:
+    def read_config(fp):
+        config = configparser.SafeConfigParser()
+        config.readfp(fp)
+        return config
+
 
 DEFAULTS_SECTION = 'cython-defaults'
 MODULE_SECTION_PREFIX = 'cython-module:'
@@ -218,8 +230,8 @@ def parse_setup_cfg(fp, cythonize=False, pkg_config=None, base_dir=''):
     """
     if pkg_config is None:
         pkg_config = _run_pkg_config
-    config = configparser.SafeConfigParser()
-    config.readfp(fp)
+
+    config = read_config(fp)
     return _expand_cython_modules(config, cythonize, pkg_config, base_dir)
 
 


### PR DESCRIPTION
Python 3.12 has removed SafeConfigParser in favor of just ConfigParser. Also they renamed the "readfp" function to "read_file". Added some code to check the version and use the new names.